### PR TITLE
Resolved missing .dll dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,11 +230,26 @@ jobs:
         shell: bash
         working-directory: aseprite/build/bin
         run: |
-          # Remove quarantine flags before zipping
+          # Create the folder to hold the .app and the helper script
+          mkdir AsepriteBundle
+          mv Aseprite.app AsepriteBundle/
+
+          # Need this to overcome mac security for external unsigned apps
+          # https://github.com/electron-userland/electron-builder/issues/8191
+          cat << 'EOF' > AsepriteBundle/fix-damaged-app.sh
+          #!/bin/bash
+          echo "Removing quarantine from Aseprite.app..."
           xattr -rd com.apple.quarantine Aseprite.app
+          echo "Done."
+          EOF
+          chmod +x AsepriteBundle/fix-damaged-app.sh
+
+          cat << 'EOF' > AsepriteBundle/README.md
+          Run the fix-damaged-app.sh script to remove the quarantine from the Aseprite.app
+          EOF
       
-          # Use ditto to preserve metadata and package as a proper .zip
-          ditto -c -k --sequesterRsrc --keepParent Aseprite.app Aseprite-${{ needs.create-release.outputs.release-tag }}-${{ runner.os }}.zip
+          # Create the zip, preserving metadata
+          ditto -c -k --sequesterRsrc --keepParent AsepriteBundle Aseprite-${{ needs.create-release.outputs.release-tag }}-${{ runner.os }}.zip
 
 
       - name: Create release (Linux + Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,37 +149,29 @@ jobs:
         shell: bash
         working-directory: aseprite
         run: ninja -C build
-
-      - name: Build OpenSSL (shared mode)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Invoke-WebRequest -Uri https://www.openssl.org/source/openssl-1.1.1w.tar.gz -OutFile openssl.tar.gz
-          tar -xzf openssl.tar.gz
-          cd openssl-1.1.1w
-      
-          # Set up MSVC environment
-          $vcvars = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-          if (-Not (Test-Path $vcvars)) {
-            throw "Could not find vcvars64.bat"
-          }
-      
-          # Configure OpenSSL in shared mode
-          cmd /c "`"$vcvars`" && perl Configure VC-WIN64A shared && nmake && nmake install"
-      
-          # Find installed DLLs
-          $dlls = Get-ChildItem -Recurse -Filter *.dll | Where-Object { $_.Name -like "libcrypto*" -or $_.Name -like "libssl*" }
-      
-          # Copy DLLs into Aseprite bin folder
-          foreach ($dll in $dlls) {
-            Copy-Item $dll.FullName -Destination ../aseprite/build/bin -Force
-          }
-
         
       - name: Clean Up Build folder
         shell: bash
         working-directory: aseprite/build/bin
         run: find . -mindepth 1 ! \( -name 'aseprite' -o -name 'aseprite.exe' -o -name 'data' -prune \) -exec rm -rf {} +
+
+      - name: Download and extract OpenSSL DLLs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: aseprite/build/bin
+        run: |
+          # Download the zip from https://wiki.overbyte.eu/wiki/index.php/ICS_Download
+          # This binary provider comes from a suggested 3rd party list on the official opensll github
+          Invoke-WebRequest -Uri "https://wiki.overbyte.eu/arch/openssl-1.0.2u-win64.zip" -OutFile dlls.zip
+          
+          # Extract dlls into same path as the .exe
+          Expand-Archive -Path dlls.zip -DestinationPath temp_dlls
+          Copy-Item temp_dlls\libcrypto-1_1-x64.dll .
+          Copy-Item temp_dlls\libssl-1_1-x64.dll .
+
+          # Remove the ssl zip + temp folder from the final release
+          Remove-Item -Recurse -Force temp_dlls
+          Remove-Item dlls.zip
 
       - name: Make portable zip
         working-directory: aseprite/build/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,18 +234,35 @@ jobs:
           mkdir AsepriteBundle
           mv Aseprite.app AsepriteBundle/
 
-          # Need this to overcome mac security for external unsigned apps
+          # Need to overcome mac security for external unsigned apps
           # https://github.com/electron-userland/electron-builder/issues/8191
-          cat << 'EOF' > AsepriteBundle/fix-damaged-app.sh
-          #!/bin/bash
-          echo "Removing quarantine from Aseprite.app..."
-          xattr -rd com.apple.quarantine Aseprite.app
-          echo "Done."
-          EOF
-          chmod +x AsepriteBundle/fix-damaged-app.sh
-
           cat << 'EOF' > AsepriteBundle/README.md
-          Run the fix-damaged-app.sh script to remove the quarantine from the Aseprite.app
+          # Fixing "damaged and can't be opened" on macOS
+
+          If you see an error saying Aseprite is “damaged and can’t be opened,” this is caused by macOS quarantine flags applied when downloading from the internet.
+          
+          Follow these steps to fix it:
+          
+          1. Open Terminal:
+             - Press Command + Spacebar
+             - Type "Terminal" and press Enter
+          
+          2. In the Terminal window, type the word `cd` followed by a space, then drag the folder containing this app into the Terminal window. This will insert the folder path.
+          
+             Example:
+             cd /Users/yourname/Downloads/AsepriteBundle
+          
+          3. Press Enter
+          
+          4. Copy and paste the following line
+             xattr -rd com.apple.quarantine Aseprite.app
+          
+          5. Press Enter
+          
+          After that, you should be able to double-click Aseprite.app and open it normally.
+          
+          You only need to do this once after downloading.
+
           EOF
       
           # Create the zip, preserving metadata

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,14 +225,20 @@ jobs:
           </plist>
           EOF
 
-      - name: Remove quarantine flag (macOS Gatekeeper)
+      - name: Create release (macOS)
         if: runner.os == 'macOS'
         shell: bash
         working-directory: aseprite/build/bin
-        run: xattr -rd com.apple.quarantine Aseprite.app
+        run: |
+          # Remove quarantine flags before zipping
+          xattr -rd com.apple.quarantine Aseprite.app
+      
+          # Use ditto to preserve metadata and package as a proper .zip
+          ditto -c -k --sequesterRsrc --keepParent Aseprite.app Aseprite-${{ needs.create-release.outputs.release-tag }}-${{ runner.os }}.zip
 
 
-      - name: Create release
+      - name: Create release (Linux + Windows)
+        if: runner.os != 'macOS'
         working-directory: aseprite/build/bin
         run: 7z -tzip a Aseprite-${{ needs.create-release.outputs.release-tag }}-${{ runner.os }}.zip *
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,15 +150,32 @@ jobs:
         working-directory: aseprite
         run: ninja -C build
 
-      - name: Download OpenSSL DLLs (Windows)
+      - name: Build OpenSSL (shared mode)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri https://slproweb.com/download/Win64OpenSSL-1_1_1w.exe -OutFile openssl.exe
-          Start-Process .\openssl.exe -ArgumentList '/silent', '/verysilent', '/dir=C:\OpenSSL-Win64' -Wait
-          Copy-Item 'C:\OpenSSL-Win64\bin\libcrypto-1_1-x64.dll' -Destination 'aseprite/build/bin'
-          Copy-Item 'C:\OpenSSL-Win64\bin\libssl-1_1-x64.dll' -Destination 'aseprite/build/bin'
+          Invoke-WebRequest -Uri https://www.openssl.org/source/openssl-1.1.1w.tar.gz -OutFile openssl.tar.gz
+          tar -xzf openssl.tar.gz
+          cd openssl-1.1.1w
+      
+          # Set up MSVC environment
+          $vcvars = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+          if (-Not (Test-Path $vcvars)) {
+            throw "Could not find vcvars64.bat"
+          }
+      
+          # Configure OpenSSL in shared mode
+          cmd /c "`"$vcvars`" && perl Configure VC-WIN64A shared && nmake && nmake install"
+      
+          # Find installed DLLs
+          $dlls = Get-ChildItem -Recurse -Filter *.dll | Where-Object { $_.Name -like "libcrypto*" -or $_.Name -like "libssl*" }
+      
+          # Copy DLLs into Aseprite bin folder
+          foreach ($dll in $dlls) {
+            Copy-Item $dll.FullName -Destination ../aseprite/build/bin -Force
+          }
 
+        
       - name: Clean Up Build folder
         shell: bash
         working-directory: aseprite/build/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,15 @@ jobs:
         working-directory: aseprite
         run: ninja -C build
 
+      - name: Download OpenSSL DLLs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://slproweb.com/download/Win64OpenSSL-1_1_1w.exe -OutFile openssl.exe
+          Start-Process .\openssl.exe -ArgumentList '/silent', '/verysilent', '/dir=C:\OpenSSL-Win64' -Wait
+          Copy-Item 'C:\OpenSSL-Win64\bin\libcrypto-1_1-x64.dll' -Destination 'aseprite/build/bin'
+          Copy-Item 'C:\OpenSSL-Win64\bin\libssl-1_1-x64.dll' -Destination 'aseprite/build/bin'
+
       - name: Clean Up Build folder
         shell: bash
         working-directory: aseprite/build/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,13 @@ jobs:
           </plist>
           EOF
 
+      - name: Remove quarantine flag (macOS Gatekeeper)
+        if: runner.os == 'macOS'
+        shell: bash
+        working-directory: aseprite/build/bin
+        run: xattr -rd com.apple.quarantine Aseprite.app
+
+
       - name: Create release
         working-directory: aseprite/build/bin
         run: 7z -tzip a Aseprite-${{ needs.create-release.outputs.release-tag }}-${{ runner.os }}.zip *

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           # Download the zip from https://wiki.overbyte.eu/wiki/index.php/ICS_Download
           # This binary provider comes from a suggested 3rd party list on the official opensll github
-          Invoke-WebRequest -Uri "https://wiki.overbyte.eu/arch/openssl-1.0.2u-win64.zip" -OutFile dlls.zip
+          Invoke-WebRequest -Uri "https://wiki.overbyte.eu/arch/openssl-1.1.1w-win64.zip" -OutFile dlls.zip
           
           # Extract dlls into same path as the .exe
           Expand-Archive -Path dlls.zip -DestinationPath temp_dlls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,11 @@ jobs:
         shell: bash
         working-directory: aseprite/build/bin
         run: find . -mindepth 1 ! \( -name 'aseprite' -o -name 'aseprite.exe' -o -name 'data' -prune \) -exec rm -rf {} +
-
+      
+      - name: Make portable zip
+        working-directory: aseprite/build/bin
+        run: echo '# This file is here so Aseprite behaves as a portable program' > aseprite.ini
+        
       - name: Download and extract OpenSSL DLLs (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -220,11 +224,6 @@ jobs:
           </dict>
           </plist>
           EOF
-
-
-      - name: Make portable zip
-        working-directory: aseprite/build/bin
-        run: echo '# This file is here so Aseprite behaves as a portable program' > aseprite.ini
 
       - name: Create release
         working-directory: aseprite/build/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,55 @@ jobs:
           Remove-Item -Recurse -Force temp_dlls
           Remove-Item dlls.zip
 
+      - name: Create macOS .app bundle
+        if: runner.os == 'macOS'
+        shell: bash
+        working-directory: aseprite/build/bin
+        run: |
+          mkdir -p Aseprite.app/Contents/MacOS
+          mkdir -p Aseprite.app/Contents/Resources
+      
+          # Move the built binary into the app bundle
+          mv aseprite Aseprite.app/Contents/MacOS/
+          mv data Aseprite.app/Contents/Resources/
+          # Don't know if ini is needed on mac
+          mv aseprite.ini Aseprite.app/Contents/Resources/
+
+          # Create app icns
+          mkdir -p Aseprite.iconset
+          for file in Aseprite.app/Contents/Resources/data/icons/ase*.png; do
+              num=$(basename "$file" | grep -E -o "\d+")
+              if (( num % 16 == 0 )); then
+                  cp "$file" "Aseprite.iconset/icon_${num}x${num}.png"
+              fi
+          done
+          iconutil -c icns Aseprite.iconset
+          rm -R Aseprite.iconset
+          mv Aseprite.icns Aseprite.app/Contents/Resources/
+      
+          # Create minimal Info.plist
+          cat > Aseprite.app/Contents/Info.plist <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>CFBundleExecutable</key>
+              <string>aseprite</string>
+              <key>CFBundleIdentifier</key>
+              <string>org.aseprite.app</string>
+              <key>CFBundleName</key>
+              <string>Aseprite</string>
+              <key>CFBundleVersion</key>
+              <string>${{ needs.create-release.outputs.release-tag }}</string>
+              <key>CFBundlePackageType</key>
+              <string>APPL</string>
+              <key>CFBundleIconFile</key>
+              <string>Aseprite.icns</string>
+          </dict>
+          </plist>
+          EOF
+
+
       - name: Make portable zip
         working-directory: aseprite/build/bin
         run: echo '# This file is here so Aseprite behaves as a portable program' > aseprite.ini


### PR DESCRIPTION
Resolved issues with "missing LIBCRYPTO-1_1-X64.DLL" errors by including pre-compiled openssl windows binaries